### PR TITLE
Updates for QGIS 3.2

### DIFF
--- a/chainagetool.py
+++ b/chainagetool.py
@@ -70,7 +70,7 @@ def create_points_at(startpoint,
     # set the first point at startpoint
     point = geom.interpolate(startpoint)
     # convert 3D geometry to 2D geometry as OGR seems to have problems with this
-    point = QgsGeometry.fromPoint(point.asPoint())
+    point = QgsGeometry.fromPointXY(point.asPoint())
 
     field_id = QgsField(name="id", type=QVariant.Int)
     field = QgsField(name="dist", type=QVariant.Double)

--- a/qchainagedialog.py
+++ b/qchainagedialog.py
@@ -92,7 +92,7 @@ class QChainageDialog(QDialog, Ui_QChainageDialog):
             
         units = layer.crs().mapUnits()
 
-        self.da.setSourceCrs(layer.crs())
+        self.da.setSourceCrs(layer.crs(), QgsProject.instance().transformContext())
         self.da.setEllipsoid( QgsProject.instance().ellipsoid())
 
         self.currentUnits = self.UnitsComboBox.findData(units)


### PR DESCRIPTION
  Rename QgsGeometry::fromPoint to QgsGeometry::fromPointXY
  QgsDistanceArea.setSourceCrs() now requires a QgsTransformContext